### PR TITLE
Inclusão validação se o número já está com +55

### DIFF
--- a/pypix/pix.py
+++ b/pypix/pix.py
@@ -209,8 +209,11 @@ class Pix:
         if self.key:
             if len(self.key) == 11 and validate_cpf(self.key):
                 self.key = self.key
-            elif validate_phone(self.key) and not self.key.startswith('+55'):
-                self.key = f'+55{self.key}'
+            elif validate_phone(self.key):
+                self.key = (
+                    f'+55{self.key}' if not self.key.startswith("+55")
+                    else self.key
+                )
             info_string += get_value('01', self.key)
         elif self.default_url_pix:
             info_string += get_value('25', self.default_url_pix)

--- a/pypix/pix.py
+++ b/pypix/pix.py
@@ -209,7 +209,7 @@ class Pix:
         if self.key:
             if len(self.key) == 11 and validate_cpf(self.key):
                 self.key = self.key
-            elif validate_phone(self.key):
+            elif validate_phone(self.key) and not self.key.startswith('+55'):
                 self.key = f'+55{self.key}'
             info_string += get_value('01', self.key)
         elif self.default_url_pix:


### PR DESCRIPTION
Ao chamar o pix.get_br_code() após a geração do QRCODE: 

base64qr = pix.save_qrcode(
        './qrcode.png',
        color="black",
        box_size=7,
        border=1,
    )

O valor da chave fica com o valor "+55"  duplicado